### PR TITLE
Adopt the baseline dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,42 @@
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+# Dependabot config for a package on the shared CI baseline.
+# Copy to .github/dependabot.yml in the package repo.
 version: 2
 updates:
-
-  - package-ecosystem: "github-actions"
+  # Composer — keeps this package's dev tooling current (pint, phpstan/larastan,
+  # pest + plugins, rector, testbench). Grouped into one weekly PR to cut noise.
+  # The runtime `require` block is constrained loosely on purpose; review those bumps.
+  - package-ecosystem: composer
     directory: "/"
     schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
+      interval: weekly
+    open-pull-requests-limit: 5
+    # Wait for a release to settle before opening a PR — longer for majors.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      production-dependencies:
+        dependency-type: production
+
+  # GitHub Actions — covers any actions the package repo adds (release, changelog, etc.).
+  #
+  # The awcodes/.github caller is excluded on purpose. It tracks the moving major tag
+  # (@v1) so CI fixes reach every package at once (docs/versioning.md). Dependabot has no
+  # concept of a moving major: it reads @v1 as version "1" and offers the newest semver
+  # tag, which pins the package to a snapshot and can even be a downgrade, since v1 moves
+  # ahead of older release tags. Moving to a new major is a deliberate migration, not a
+  # Dependabot bump.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "awcodes/.github/*"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Syncs `templates/dependabot.yml` from [awcodes/.github](https://github.com/awcodes/.github) (post-[#2](https://github.com/awcodes/.github/pull/2)), replacing the hand-rolled config that predates the shared CI baseline. This repo migrated on Jul 13, three days before the template shipped in v1.2.0.

## Why now — this one can fire on its own

The old config's `github-actions` ecosystem had **no `ignore` rule**, so it would catch the `awcodes/.github` caller and offer:

> Bump `awcodes/.github/.github/workflows/laravel-package.yml` from 1 to 1.1.0

That reads as **semver-minor**, which `dependabot-auto-merge.yml` merges automatically — and `main` has no required status checks, so it would land unreviewed. The result: this package silently pinned to a snapshot instead of tracking the moving major per [docs/versioning.md](https://github.com/awcodes/.github/blob/main/docs/versioning.md), and **downgraded** — `v1` points at v1.2.0's commit (`f7513ab`), while `v1.1.0` is from Jul 8.

This isn't hypothetical: the semver-minor auto-merge path last ran successfully on #20 (`fetch-metadata 3.0.0 → 3.1.0`). The caller only became a tracked dependency when #22 merged, so the next weekly run is the first that could catch it. [postal-codes#7](https://github.com/awcodes/postal-codes/pull/7) was the identical bump, caught only because that repo has no auto-merge.

## Changes

- **`ignore: awcodes/.github/*`** on the github-actions ecosystem — the actual fix.
- **Adds composer updates** (grouped dev + runtime, weekly, with cooldown). This repo had no composer dependabot coverage at all.
- Drops `labels: [dependencies]` — auto-merge keys off the dependabot actor and metadata, not labels, so nothing depends on it.

`dependabot-auto-merge.yml` stays as-is; the `ignore` rule is what makes it safe.

## Note

Config-only, so CI does not run here — `.github/dependabot.yml` isn't in the caller's path filters. Expected, not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)